### PR TITLE
fix: eslintrc linebreak-style

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,7 +44,7 @@ module.exports = {
     'import/no-extraneous-dependencies': 'off',
     'import/prefer-default-export': 'off',
     'prefer-promise-reject-errors': 'off',
-
+    'linebreak-style': ["off", "windows"],
     // allow console.log during development only
     'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'off',
     // allow debugger during development only


### PR DESCRIPTION
`fix`: eslintrc rules ，关闭 eslint 在 windows 中换行符风格验证